### PR TITLE
Add structured deliverables and acceptance criteria to backlog and roadmap builder

### DIFF
--- a/backlog_github_project.json
+++ b/backlog_github_project.json
@@ -6,78 +6,923 @@
       "end": "Fim previsto"
     },
     "milestone_durations": {
-      "M1": {"value": 15, "unit": "days"},
-      "M2": {"value": 1, "unit": "months"},
-      "M3": {"value": 3, "unit": "months"},
-      "M4": {"value": 1, "unit": "months"},
-      "M5": {"value": 15, "unit": "days"}
+      "M1": {
+        "value": 15,
+        "unit": "days"
+      },
+      "M2": {
+        "value": 1,
+        "unit": "months"
+      },
+      "M3": {
+        "value": 3,
+        "unit": "months"
+      },
+      "M4": {
+        "value": 1,
+        "unit": "months"
+      },
+      "M5": {
+        "value": 15,
+        "unit": "days"
+      }
     }
   },
   "labels": [
-    {"name": "fase:i", "color": "1D76DB", "description": "Fase I - Exploração"},
-    {"name": "fase:ii", "color": "5319E7", "description": "Fase II - Viabilidade e Concepção"},
-    {"name": "fase:iii", "color": "0E8A16", "description": "Fase III - MVP"},
-    {"name": "fase:iv", "color": "FBCA04", "description": "Fase IV - Piloto"},
-    {"name": "fase:v", "color": "D93F0B", "description": "Fase V - Escala"},
-    {"name": "tipo:epic", "color": "BFDADC", "description": "Issue épica"},
-    {"name": "tipo:atividade", "color": "C2E0C6", "description": "Atividade"},
-    {"name": "tipo:entregavel", "color": "F9D0C4", "description": "Entregável"},
-    {"name": "tipo:gate", "color": "E4E669", "description": "Gate de decisão"}
+    {
+      "name": "fase:i",
+      "color": "1D76DB",
+      "description": "Fase I - Exploração"
+    },
+    {
+      "name": "fase:ii",
+      "color": "5319E7",
+      "description": "Fase II - Viabilidade e Concepção"
+    },
+    {
+      "name": "fase:iii",
+      "color": "0E8A16",
+      "description": "Fase III - MVP"
+    },
+    {
+      "name": "fase:iv",
+      "color": "FBCA04",
+      "description": "Fase IV - Piloto"
+    },
+    {
+      "name": "fase:v",
+      "color": "D93F0B",
+      "description": "Fase V - Escala"
+    },
+    {
+      "name": "tipo:epic",
+      "color": "BFDADC",
+      "description": "Issue épica"
+    },
+    {
+      "name": "tipo:atividade",
+      "color": "C2E0C6",
+      "description": "Atividade"
+    },
+    {
+      "name": "tipo:entregavel",
+      "color": "F9D0C4",
+      "description": "Entregável"
+    },
+    {
+      "name": "tipo:gate",
+      "color": "E4E669",
+      "description": "Gate de decisão"
+    },
+    {
+      "name": "dados",
+      "color": "0052CC",
+      "description": "Engenheiro de Dados"
+    },
+    {
+      "name": "ml",
+      "color": "8E44AD",
+      "description": "Engenheiro de ML"
+    },
+    {
+      "name": "software",
+      "color": "2EA44F",
+      "description": "Engenheiro de Software"
+    },
+    {
+      "name": "governança",
+      "color": "6F42C1",
+      "description": "Comitê / decisão formal"
+    }
   ],
   "milestones": [
-    {"key": "M1", "title": "M1 - Exploração", "description": "Portfólio priorizado e problema selecionado."},
-    {"key": "M2", "title": "M2 - Viabilidade e Concepção", "description": "Viabilidade comprovada e caso de uso especificado."},
-    {"key": "M3", "title": "M3 - MVP", "description": "MVP funcional em homologação."},
-    {"key": "M4", "title": "M4 - Piloto Controlado", "description": "Validação de campo e recomendação para escala."},
-    {"key": "M5", "title": "M5 - Escala e Operação", "description": "Solução operacionalizada com transferência tecnológica."}
+    {
+      "key": "M1",
+      "title": "M1 - Exploração",
+      "description": "Portfólio priorizado e problema selecionado."
+    },
+    {
+      "key": "M2",
+      "title": "M2 - Viabilidade e Concepção",
+      "description": "Viabilidade comprovada e caso de uso especificado."
+    },
+    {
+      "key": "M3",
+      "title": "M3 - MVP",
+      "description": "MVP funcional em homologação."
+    },
+    {
+      "key": "M4",
+      "title": "M4 - Piloto Controlado",
+      "description": "Validação de campo e recomendação para escala."
+    },
+    {
+      "key": "M5",
+      "title": "M5 - Escala e Operação",
+      "description": "Solução operacionalizada com transferência tecnológica."
+    }
   ],
   "issues": [
-    {"title": "[Atividade] Levantar problemas e oportunidades com órgão demandante", "milestone": "M1", "labels": ["fase:i", "tipo:atividade"]},
-    {"title": "[Atividade] Avaliar impacto público e complexidade preliminar", "milestone": "M1", "labels": ["fase:i", "tipo:atividade"]},
-    {"title": "[Atividade] Priorizar portfólio com critérios acordados", "milestone": "M1", "labels": ["fase:i", "tipo:atividade"]},
-    {"title": "[Entregável] Documento de Portfólio de Problemas e Oportunidades de IA", "milestone": "M1", "labels": ["fase:i", "tipo:entregavel"]},
-    {"title": "[Atividade] Detalhar problema prioritário (objetivos, stakeholders, dados, riscos)", "milestone": "M1", "labels": ["fase:i", "tipo:atividade"]},
-    {"title": "[Entregável] Documento de Detalhamento do Problema Priorizado", "milestone": "M1", "labels": ["fase:i", "tipo:entregavel"]},
-    {"title": "[Gate] Validar critérios de saída da Fase I (M1)", "milestone": "M1", "labels": ["fase:i", "tipo:gate"]},
-
-    {"title": "[Atividade] Executar EDA e mapear qualidade/disponibilidade de dados", "milestone": "M2", "labels": ["fase:ii", "tipo:atividade"]},
-    {"title": "[Atividade] Avaliar viabilidade técnica, científica e operacional", "milestone": "M2", "labels": ["fase:ii", "tipo:atividade"]},
-    {"title": "[Atividade] Definir métricas técnicas e limiares mínimos de aceitação", "milestone": "M2", "labels": ["fase:ii", "tipo:atividade"]},
-    {"title": "[Atividade] Consolidar riscos e plano de mitigação", "milestone": "M2", "labels": ["fase:ii", "tipo:atividade"]},
-    {"title": "[Atividade] Especificar caso de uso de IA e requisitos (funcionais e não funcionais)", "milestone": "M2", "labels": ["fase:ii", "tipo:atividade"]},
-    {"title": "[Entregável] Documento de Viabilidade (técnica/científica/operacional)", "milestone": "M2", "labels": ["fase:ii", "tipo:entregavel"]},
-    {"title": "[Entregável] Relatório EDA", "milestone": "M2", "labels": ["fase:ii", "tipo:entregavel"]},
-    {"title": "[Entregável] Plano preliminar do MVP", "milestone": "M2", "labels": ["fase:ii", "tipo:entregavel"]},
-    {"title": "[Entregável] Documento de Especificação do Caso de Uso de IA", "milestone": "M2", "labels": ["fase:ii", "tipo:entregavel"]},
-    {"title": "[Gate] Aprovar avanço para MVP (M2)", "milestone": "M2", "labels": ["fase:ii", "tipo:gate"]},
-
-    {"title": "[Atividade] Implementar pipeline de dados versionado", "milestone": "M3", "labels": ["fase:iii", "tipo:atividade"]},
-    {"title": "[Atividade] Treinar e versionar modelo MVP", "milestone": "M3", "labels": ["fase:iii", "tipo:atividade"]},
-    {"title": "[Atividade] Implementar avaliação offline e baseline comparativa", "milestone": "M3", "labels": ["fase:iii", "tipo:atividade"]},
-    {"title": "[Atividade] Configurar CI/CD do repositório", "milestone": "M3", "labels": ["fase:iii", "tipo:atividade"]},
-    {"title": "[Atividade] Implementar protótipo funcional (API/serviço/aplicação)", "milestone": "M3", "labels": ["fase:iii", "tipo:atividade"]},
-    {"title": "[Entregável] Repositório com CI/CD e documentação técnica", "milestone": "M3", "labels": ["fase:iii", "tipo:entregavel"]},
-    {"title": "[Entregável] Pipeline + dataset preparado e documentado", "milestone": "M3", "labels": ["fase:iii", "tipo:entregavel"]},
-    {"title": "[Entregável] Modelo MVP + relatório de avaliação offline", "milestone": "M3", "labels": ["fase:iii", "tipo:entregavel"]},
-    {"title": "[Entregável] MVP em homologação", "milestone": "M3", "labels": ["fase:iii", "tipo:entregavel"]},
-    {"title": "[Gate] Validar saída da Fase III (M3)", "milestone": "M3", "labels": ["fase:iii", "tipo:gate"]},
-
-    {"title": "[Atividade] Implantar MVP em ambiente piloto controlado", "milestone": "M4", "labels": ["fase:iv", "tipo:atividade"]},
-    {"title": "[Atividade] Monitorar KPIs técnicos e de negócio no piloto", "milestone": "M4", "labels": ["fase:iv", "tipo:atividade"]},
-    {"title": "[Atividade] Coletar feedback de usuários e curar Golden Set", "milestone": "M4", "labels": ["fase:iv", "tipo:atividade"]},
-    {"title": "[Atividade] Avaliar salvaguardas éticas e conformidade operacional", "milestone": "M4", "labels": ["fase:iv", "tipo:atividade"]},
-    {"title": "[Entregável] Relatório de Validação de Campo", "milestone": "M4", "labels": ["fase:iv", "tipo:entregavel"]},
-    {"title": "[Entregável] Golden Set do Piloto", "milestone": "M4", "labels": ["fase:iv", "tipo:entregavel"]},
-    {"title": "[Entregável] Parecer de Ajuste Ético", "milestone": "M4", "labels": ["fase:iv", "tipo:entregavel"]},
-    {"title": "[Gate] Recomendação formal para escala (M4)", "milestone": "M4", "labels": ["fase:iv", "tipo:gate"]},
-
-    {"title": "[Atividade] Preparar release package de produção", "milestone": "M5", "labels": ["fase:v", "tipo:atividade"]},
-    {"title": "[Atividade] Executar transferência tecnológica para órgão demandante", "milestone": "M5", "labels": ["fase:v", "tipo:atividade"]},
-    {"title": "[Atividade] Definir e operacionalizar matriz de monitoramento/observabilidade", "milestone": "M5", "labels": ["fase:v", "tipo:atividade"]},
-    {"title": "[Atividade] Formalizar governança, papéis e responsabilidades", "milestone": "M5", "labels": ["fase:v", "tipo:atividade"]},
-    {"title": "[Entregável] Release package validado", "milestone": "M5", "labels": ["fase:v", "tipo:entregavel"]},
-    {"title": "[Entregável] Kit de Transferência Tecnológica", "milestone": "M5", "labels": ["fase:v", "tipo:entregavel"]},
-    {"title": "[Entregável] Termo de Transferência de Tecnologia assinado", "milestone": "M5", "labels": ["fase:v", "tipo:entregavel"]},
-    {"title": "[Gate] Encerramento formal do projeto (M5)", "milestone": "M5", "labels": ["fase:v", "tipo:gate"]}
+    {
+      "title": "[Atividade] Levantar problemas e oportunidades com órgão demandante",
+      "milestone": "M1",
+      "labels": [
+        "fase:i",
+        "tipo:atividade",
+        "governança"
+      ],
+      "description": "Realizar oficinas e entrevistas com o órgão demandante para identificar dores, oportunidades e objetivos de negócio que possam ser endereçados com IA, registrando contexto, impacto esperado e restrições institucionais.",
+      "entregaveis": [
+        "Ata das oficinas/entrevistas com participantes e contexto.",
+        "Lista estruturada de problemas e oportunidades com evidências."
+      ],
+      "criterios_aceite": [
+        "Órgão demandante valida que o levantamento representa as principais dores.",
+        "Cada problema possui descrição, unidade impactada e evidência de origem."
+      ]
+    },
+    {
+      "title": "[Atividade] Avaliar impacto público e complexidade preliminar",
+      "milestone": "M1",
+      "labels": [
+        "fase:i",
+        "tipo:atividade",
+        "governança"
+      ],
+      "description": "Aplicar critérios iniciais de priorização para estimar impacto público potencial, urgência, complexidade técnica e esforço de implementação de cada problema identificado.",
+      "entregaveis": [
+        "Matriz de impacto público x complexidade para os problemas mapeados.",
+        "Pontuação preliminar por critérios acordados."
+      ],
+      "criterios_aceite": [
+        "Todos os problemas possuem pontuação documentada.",
+        "Critérios e pesos utilizados estão explícitos e revisáveis."
+      ]
+    },
+    {
+      "title": "[Atividade] Priorizar portfólio com critérios acordados",
+      "milestone": "M1",
+      "labels": [
+        "fase:i",
+        "tipo:atividade",
+        "governança"
+      ],
+      "description": "Consolidar e ranquear o portfólio de problemas com base em critérios acordados entre as partes (impacto, viabilidade, risco e custo), produzindo justificativa de priorização.",
+      "entregaveis": [
+        "Ranking priorizado do portfólio com justificativas.",
+        "Registro da decisão de priorização com stakeholders."
+      ],
+      "criterios_aceite": [
+        "Top prioridades possuem racional de escolha claro.",
+        "Há concordância formal dos responsáveis do órgão e time técnico."
+      ]
+    },
+    {
+      "title": "[Entregável] Documento de Portfólio de Problemas e Oportunidades de IA",
+      "milestone": "M1",
+      "labels": [
+        "fase:i",
+        "tipo:entregavel",
+        "governança"
+      ],
+      "description": "Produzir documento formal com a lista estruturada de problemas e oportunidades de IA, critérios usados na análise, ranking final e recomendação de foco para o próximo ciclo.",
+      "entregaveis": [
+        "Documento consolidado do portfólio versionado.",
+        "Anexo com metodologia, critérios e ranking final."
+      ],
+      "criterios_aceite": [
+        "Documento cobre problemas, oportunidades e recomendação de foco.",
+        "Documento aprovado e publicado no repositório/projeto."
+      ]
+    },
+    {
+      "title": "[Atividade] Detalhar problema prioritário (objetivos, stakeholders, dados, riscos)",
+      "milestone": "M1",
+      "labels": [
+        "fase:i",
+        "tipo:atividade",
+        "dados",
+        "governança"
+      ],
+      "description": "Detalhar o problema priorizado com definição de objetivos, stakeholders envolvidos, fontes de dados, hipóteses, riscos e premissas para orientar a fase de viabilidade.",
+      "entregaveis": [
+        "Ficha do problema prioritário (objetivos, stakeholders, dados e riscos).",
+        "Mapa de premissas e restrições institucionais."
+      ],
+      "criterios_aceite": [
+        "Escopo e objetivo do problema estão mensuráveis.",
+        "Fontes de dados e riscos iniciais foram identificados e validados."
+      ]
+    },
+    {
+      "title": "[Entregável] Documento de Detalhamento do Problema Priorizado",
+      "milestone": "M1",
+      "labels": [
+        "fase:i",
+        "tipo:entregavel",
+        "dados",
+        "governança"
+      ],
+      "description": "Consolidar em documento o escopo do problema prioritário, requisitos iniciais, riscos mapeados e critérios que sustentam a decisão de avançar para a Fase II.",
+      "entregaveis": [
+        "Documento de detalhamento do problema priorizado.",
+        "Seção de requisitos iniciais, riscos e próximos passos."
+      ],
+      "criterios_aceite": [
+        "Documento permite iniciar a fase de viabilidade sem lacunas críticas.",
+        "Aprovação formal dos responsáveis registrada."
+      ]
+    },
+    {
+      "title": "[Gate] Validar critérios de saída da Fase I (M1)",
+      "milestone": "M1",
+      "labels": [
+        "fase:i",
+        "tipo:gate",
+        "governança"
+      ],
+      "description": "Conduzir reunião de gate para confirmar portfólio validado, priorização concluída, decisão explícita de continuidade e detalhamento suficiente do problema para início da Fase II.",
+      "entregaveis": [
+        "Checklist de saída da Fase I preenchido.",
+        "Ata de gate com decisão de continuidade/não continuidade."
+      ],
+      "criterios_aceite": [
+        "Todos os critérios de saída de M1 estão avaliados.",
+        "Decisão formal do comitê registrada com responsáveis."
+      ]
+    },
+    {
+      "title": "[Atividade] Executar EDA e mapear qualidade/disponibilidade de dados",
+      "milestone": "M2",
+      "labels": [
+        "fase:ii",
+        "tipo:atividade",
+        "dados",
+        "ml"
+      ],
+      "description": "Executar análise exploratória dos dados para avaliar cobertura, consistência, qualidade, vieses, lacunas, disponibilidade e esforço de preparo necessário ao caso de uso.",
+      "entregaveis": [
+        "Notebook/relatório EDA com estatísticas e diagnósticos de qualidade.",
+        "Inventário de fontes com disponibilidade e lacunas."
+      ],
+      "criterios_aceite": [
+        "Cobertura, qualidade e principais vieses dos dados foram medidos.",
+        "Há conclusão sobre aptidão dos dados para o caso de uso."
+      ]
+    },
+    {
+      "title": "[Atividade] Avaliar viabilidade técnica, científica e operacional",
+      "milestone": "M2",
+      "labels": [
+        "fase:ii",
+        "tipo:atividade",
+        "dados",
+        "ml",
+        "governança"
+      ],
+      "description": "Avaliar se há viabilidade técnica, científica e operacional para o caso de uso, considerando maturidade dos dados, alternativas de modelagem, infraestrutura e capacidade de adoção.",
+      "entregaveis": [
+        "Matriz de viabilidade técnica/científica/operacional.",
+        "Parecer com recomendação de continuidade."
+      ],
+      "criterios_aceite": [
+        "Avaliação considera dados, arquitetura, operação e adoção.",
+        "Riscos críticos possuem estratégia de mitigação definida."
+      ]
+    },
+    {
+      "title": "[Atividade] Definir métricas técnicas e limiares mínimos de aceitação",
+      "milestone": "M2",
+      "labels": [
+        "fase:ii",
+        "tipo:atividade",
+        "ml",
+        "governança"
+      ],
+      "description": "Definir métricas de desempenho e qualidade do modelo, além de limiares mínimos de aceitação para orientar decisão de avanço, testes e validação do MVP.",
+      "entregaveis": [
+        "Catálogo de métricas técnicas e de impacto do caso de uso.",
+        "Tabela de limiares mínimos para avanço do MVP."
+      ],
+      "criterios_aceite": [
+        "Cada métrica possui definição de cálculo e fonte de dados.",
+        "Limiar mínimo aprovado para decisão de gate."
+      ]
+    },
+    {
+      "title": "[Atividade] Consolidar riscos e plano de mitigação",
+      "milestone": "M2",
+      "labels": [
+        "fase:ii",
+        "tipo:atividade",
+        "governança"
+      ],
+      "description": "Mapear riscos de dados, modelagem, operação, ética e conformidade, classificando impacto/probabilidade e estabelecendo plano de mitigação com responsáveis.",
+      "entregaveis": [
+        "Registro de riscos priorizados (probabilidade x impacto).",
+        "Plano de mitigação com donos e prazos."
+      ],
+      "criterios_aceite": [
+        "Riscos críticos têm ação de mitigação e responsável definido.",
+        "Plano foi revisado com governança do projeto."
+      ]
+    },
+    {
+      "title": "[Atividade] Especificar caso de uso de IA e requisitos (funcionais e não funcionais)",
+      "milestone": "M2",
+      "labels": [
+        "fase:ii",
+        "tipo:atividade",
+        "software",
+        "governança"
+      ],
+      "description": "Especificar o caso de uso de IA com escopo funcional, requisitos não funcionais, integrações, restrições legais e critérios de sucesso técnico e de impacto público.",
+      "entregaveis": [
+        "Especificação funcional e não funcional do caso de uso.",
+        "Diagrama de integração e restrições legais/operacionais."
+      ],
+      "criterios_aceite": [
+        "Requisitos estão claros, testáveis e priorizados.",
+        "Stakeholders técnicos e de negócio validaram a especificação."
+      ]
+    },
+    {
+      "title": "[Entregável] Documento de Viabilidade (técnica/científica/operacional)",
+      "milestone": "M2",
+      "labels": [
+        "fase:ii",
+        "tipo:entregavel",
+        "governança"
+      ],
+      "description": "Entregar documento consolidando evidências de viabilidade técnica, científica e operacional, com conclusão objetiva sobre continuidade para desenvolvimento do MVP.",
+      "entregaveis": [
+        "Documento de viabilidade consolidado e versionado.",
+        "Recomendação formal de avançar (ou não) para MVP."
+      ],
+      "criterios_aceite": [
+        "Documento apresenta evidências e conclusão objetiva.",
+        "Aprovação da liderança/comitê registrada."
+      ]
+    },
+    {
+      "title": "[Entregável] Relatório EDA",
+      "milestone": "M2",
+      "labels": [
+        "fase:ii",
+        "tipo:entregavel",
+        "dados",
+        "ml"
+      ],
+      "description": "Entregar relatório de EDA com diagnóstico de qualidade e disponibilidade dos dados, análises descritivas, principais achados e implicações para modelagem.",
+      "entregaveis": [
+        "Relatório EDA com perfil, qualidade e lacunas de dados.",
+        "Anexos com consultas/notebooks reprodutíveis."
+      ],
+      "criterios_aceite": [
+        "Resultados EDA permitem decisão de modelagem.",
+        "Relatório possui rastreabilidade das fontes analisadas."
+      ]
+    },
+    {
+      "title": "[Entregável] Plano preliminar do MVP",
+      "milestone": "M2",
+      "labels": [
+        "fase:ii",
+        "tipo:entregavel",
+        "ml",
+        "software",
+        "governança"
+      ],
+      "description": "Produzir plano preliminar do MVP com escopo, arquitetura inicial, cronograma macro, recursos necessários, riscos e estratégia de validação.",
+      "entregaveis": [
+        "Plano de trabalho do MVP com arquitetura e cronograma.",
+        "Mapa de recursos, riscos e estratégia de validação."
+      ],
+      "criterios_aceite": [
+        "Plano é executável no prazo do marco M3.",
+        "Dependências e riscos críticos estão explicitados."
+      ]
+    },
+    {
+      "title": "[Entregável] Documento de Especificação do Caso de Uso de IA",
+      "milestone": "M2",
+      "labels": [
+        "fase:ii",
+        "tipo:entregavel",
+        "software",
+        "governança"
+      ],
+      "description": "Formalizar especificação do caso de uso contendo objetivos, requisitos, fluxos, métricas, limites operacionais e critérios de aceite para implementação.",
+      "entregaveis": [
+        "Documento final de especificação do caso de uso.",
+        "Critérios de sucesso técnico e de negócio definidos."
+      ],
+      "criterios_aceite": [
+        "Escopo e critérios de aceite estão fechados para desenvolvimento.",
+        "Documento aprovado pelo órgão demandante e equipe técnica."
+      ]
+    },
+    {
+      "title": "[Gate] Aprovar avanço para MVP (M2)",
+      "milestone": "M2",
+      "labels": [
+        "fase:ii",
+        "tipo:gate",
+        "governança"
+      ],
+      "description": "Realizar gate de decisão para aprovar o início do MVP com base em evidências de viabilidade, riscos tratados, métricas definidas e caso de uso refinado.",
+      "entregaveis": [
+        "Checklist de saída da Fase II concluído.",
+        "Ata de gate com decisão formal para início do MVP."
+      ],
+      "criterios_aceite": [
+        "Viabilidade demonstrada e métricas mínimas definidas.",
+        "Comitê aprova formalmente o avanço para M3."
+      ]
+    },
+    {
+      "title": "[Atividade] Implementar pipeline de dados versionado",
+      "milestone": "M3",
+      "labels": [
+        "fase:iii",
+        "tipo:atividade",
+        "dados",
+        "software"
+      ],
+      "description": "Construir pipeline de ingestão, transformação e validação de dados com versionamento de artefatos e rastreabilidade para suportar reprodutibilidade do MVP.",
+      "entregaveis": [
+        "Pipeline de ingestão/transformação versionado em repositório.",
+        "Documentação do fluxo de dados e versionamento."
+      ],
+      "criterios_aceite": [
+        "Pipeline executa ponta a ponta com rastreabilidade.",
+        "Processo de versionamento de dados está operacional."
+      ]
+    },
+    {
+      "title": "[Atividade] Treinar e versionar modelo MVP",
+      "milestone": "M3",
+      "labels": [
+        "fase:iii",
+        "tipo:atividade",
+        "ml",
+        "dados"
+      ],
+      "description": "Treinar o modelo inicial do MVP, registrar experimentos e versionar modelos para garantir rastreabilidade de parâmetros, dados e resultados.",
+      "entregaveis": [
+        "Versão treinada do modelo MVP registrada.",
+        "Log de experimentos e parâmetros versionados."
+      ],
+      "criterios_aceite": [
+        "Treino é reproduzível com dados e parâmetros versionados.",
+        "Modelo atende baseline mínimo definido."
+      ]
+    },
+    {
+      "title": "[Atividade] Implementar avaliação offline e baseline comparativa",
+      "milestone": "M3",
+      "labels": [
+        "fase:iii",
+        "tipo:atividade",
+        "ml",
+        "dados"
+      ],
+      "description": "Implementar rotina de avaliação offline comparando o modelo MVP com baseline de referência, documentando ganhos, limitações e critérios de desempenho.",
+      "entregaveis": [
+        "Rotina de avaliação offline automatizada.",
+        "Relatório comparativo entre MVP e baseline."
+      ],
+      "criterios_aceite": [
+        "Métricas de avaliação são calculadas de forma consistente.",
+        "Comparação indica desempenho do MVP frente ao baseline."
+      ]
+    },
+    {
+      "title": "[Atividade] Configurar CI/CD do repositório",
+      "milestone": "M3",
+      "labels": [
+        "fase:iii",
+        "tipo:atividade",
+        "software"
+      ],
+      "description": "Configurar esteiras de CI/CD para testes, validações automatizadas, build e deploy do MVP, assegurando qualidade e padronização de entregas.",
+      "entregaveis": [
+        "Pipelines de CI/CD configurados para build/test/deploy.",
+        "Políticas de qualidade e validações automáticas documentadas."
+      ],
+      "criterios_aceite": [
+        "Execução de CI ocorre em pull requests principais.",
+        "Falhas de qualidade bloqueiam integração conforme regras definidas."
+      ]
+    },
+    {
+      "title": "[Atividade] Implementar protótipo funcional (API/serviço/aplicação)",
+      "milestone": "M3",
+      "labels": [
+        "fase:iii",
+        "tipo:atividade",
+        "software",
+        "ml"
+      ],
+      "description": "Desenvolver protótipo funcional do MVP (API, serviço ou aplicação) com fluxo ponta a ponta e interface mínima para homologação.",
+      "entregaveis": [
+        "Protótipo funcional com fluxo ponta a ponta.",
+        "Guia de uso e execução em homologação."
+      ],
+      "criterios_aceite": [
+        "Protótipo responde aos cenários essenciais do caso de uso.",
+        "Integração mínima com componentes previstos foi validada."
+      ]
+    },
+    {
+      "title": "[Entregável] Repositório com CI/CD e documentação técnica",
+      "milestone": "M3",
+      "labels": [
+        "fase:iii",
+        "tipo:entregavel",
+        "software"
+      ],
+      "description": "Disponibilizar repositório versionado com pipelines de CI/CD ativos e documentação técnica suficiente para manutenção e evolução.",
+      "entregaveis": [
+        "Repositório principal com CI/CD ativo.",
+        "Documentação técnica de arquitetura e operação."
+      ],
+      "criterios_aceite": [
+        "Documentação permite setup e manutenção por outro time.",
+        "Pipelines passam nos checks definidos para o MVP."
+      ]
+    },
+    {
+      "title": "[Entregável] Pipeline + dataset preparado e documentado",
+      "milestone": "M3",
+      "labels": [
+        "fase:iii",
+        "tipo:entregavel",
+        "dados",
+        "software"
+      ],
+      "description": "Entregar pipeline de dados operacional e dataset preparado/documentado, com origem, transformações, qualidade e versionamento explicitados.",
+      "entregaveis": [
+        "Pipeline de dados pronto para execução recorrente.",
+        "Dataset preparado com dicionário de dados e versionamento."
+      ],
+      "criterios_aceite": [
+        "Dataset possui rastreabilidade de origem e transformações.",
+        "Qualidade mínima de dados documentada e aceita."
+      ]
+    },
+    {
+      "title": "[Entregável] Modelo MVP + relatório de avaliação offline",
+      "milestone": "M3",
+      "labels": [
+        "fase:iii",
+        "tipo:entregavel",
+        "ml",
+        "dados"
+      ],
+      "description": "Entregar versão do modelo MVP acompanhada de relatório de avaliação offline com métricas, comparação com baseline e análise de riscos de performance.",
+      "entregaveis": [
+        "Artefato do modelo MVP versionado.",
+        "Relatório de avaliação offline com métricas e análise."
+      ],
+      "criterios_aceite": [
+        "Métricas mínimas do MVP foram atingidas ou justificadas.",
+        "Relatório explicita limitações e próximos ajustes."
+      ]
+    },
+    {
+      "title": "[Entregável] MVP em homologação",
+      "milestone": "M3",
+      "labels": [
+        "fase:iii",
+        "tipo:entregavel",
+        "software",
+        "ml"
+      ],
+      "description": "Disponibilizar MVP funcional em ambiente de homologação para validações técnicas e de integração com atores do projeto.",
+      "entregaveis": [
+        "MVP implantado em ambiente de homologação.",
+        "Evidências de testes técnicos e integração básica."
+      ],
+      "criterios_aceite": [
+        "MVP disponível para validação dos stakeholders.",
+        "Estabilidade mínima em homologação comprovada."
+      ]
+    },
+    {
+      "title": "[Gate] Validar saída da Fase III (M3)",
+      "milestone": "M3",
+      "labels": [
+        "fase:iii",
+        "tipo:gate",
+        "governança"
+      ],
+      "description": "Conduzir gate para confirmar MVP em homologação, atendimento de métricas técnicas mínimas e validação da integração básica com sistemas legados.",
+      "entregaveis": [
+        "Checklist de saída da Fase III concluído.",
+        "Ata de gate com decisão para piloto controlado."
+      ],
+      "criterios_aceite": [
+        "MVP homologado atende métricas técnicas mínimas.",
+        "Comitê valida avanço para Fase IV."
+      ]
+    },
+    {
+      "title": "[Atividade] Implantar MVP em ambiente piloto controlado",
+      "milestone": "M4",
+      "labels": [
+        "fase:iv",
+        "tipo:atividade",
+        "software",
+        "governança"
+      ],
+      "description": "Implantar o MVP em ambiente piloto controlado com escopo delimitado, usuários definidos e plano de acompanhamento operacional.",
+      "entregaveis": [
+        "Plano e evidência de implantação no piloto.",
+        "Configuração do ambiente e público piloto documentados."
+      ],
+      "criterios_aceite": [
+        "Piloto opera com escopo e período definidos.",
+        "Riscos operacionais iniciais estão monitorados."
+      ]
+    },
+    {
+      "title": "[Atividade] Monitorar KPIs técnicos e de negócio no piloto",
+      "milestone": "M4",
+      "labels": [
+        "fase:iv",
+        "tipo:atividade",
+        "software",
+        "ml",
+        "governança"
+      ],
+      "description": "Monitorar continuamente KPIs técnicos e de negócio durante o piloto, consolidando evidências de desempenho, estabilidade e geração de valor.",
+      "entregaveis": [
+        "Painel de KPIs técnicos e de negócio do piloto.",
+        "Relatórios periódicos de desempenho e valor."
+      ],
+      "criterios_aceite": [
+        "KPIs são coletados com periodicidade acordada.",
+        "Desvios críticos geram ações corretivas registradas."
+      ]
+    },
+    {
+      "title": "[Atividade] Coletar feedback de usuários e curar Golden Set",
+      "milestone": "M4",
+      "labels": [
+        "fase:iv",
+        "tipo:atividade",
+        "dados",
+        "ml"
+      ],
+      "description": "Coletar feedback estruturado dos usuários do piloto e curar Golden Set para suporte a ajustes de modelo e validação de qualidade.",
+      "entregaveis": [
+        "Registro estruturado de feedback de usuários.",
+        "Golden Set curado e versionado para validação."
+      ],
+      "criterios_aceite": [
+        "Feedback cobre principais perfis/cenários de uso.",
+        "Golden Set atende critérios de qualidade e representatividade."
+      ]
+    },
+    {
+      "title": "[Atividade] Avaliar salvaguardas éticas e conformidade operacional",
+      "milestone": "M4",
+      "labels": [
+        "fase:iv",
+        "tipo:atividade",
+        "governança"
+      ],
+      "description": "Avaliar salvaguardas éticas, riscos de viés, aderência regulatória e conformidade operacional, propondo ajustes para uso responsável.",
+      "entregaveis": [
+        "Checklist de conformidade ética e operacional.",
+        "Relatório de riscos de viés e ações recomendadas."
+      ],
+      "criterios_aceite": [
+        "Riscos éticos relevantes foram avaliados e mitigados.",
+        "Conformidade regulatória mínima foi comprovada."
+      ]
+    },
+    {
+      "title": "[Entregável] Relatório de Validação de Campo",
+      "milestone": "M4",
+      "labels": [
+        "fase:iv",
+        "tipo:entregavel",
+        "governança"
+      ],
+      "description": "Entregar relatório de validação de campo com resultados do piloto, evidências de impacto, análise de estabilidade e recomendações de evolução.",
+      "entregaveis": [
+        "Relatório consolidado de validação de campo.",
+        "Evidências de impacto, estabilidade e limitações do piloto."
+      ],
+      "criterios_aceite": [
+        "Relatório suporta decisão de escala com dados objetivos.",
+        "Stakeholders-chave revisaram e aprovaram o material."
+      ]
+    },
+    {
+      "title": "[Entregável] Golden Set do Piloto",
+      "milestone": "M4",
+      "labels": [
+        "fase:iv",
+        "tipo:entregavel",
+        "dados",
+        "ml"
+      ],
+      "description": "Entregar Golden Set do piloto com critérios de curadoria, cobertura de cenários e qualidade assegurada para avaliação contínua.",
+      "entregaveis": [
+        "Golden Set final do piloto versionado.",
+        "Critérios de curadoria e cobertura documentados."
+      ],
+      "criterios_aceite": [
+        "Golden Set é reproduzível e auditável.",
+        "Conjunto cobre cenários críticos para avaliação contínua."
+      ]
+    },
+    {
+      "title": "[Entregável] Parecer de Ajuste Ético",
+      "milestone": "M4",
+      "labels": [
+        "fase:iv",
+        "tipo:entregavel",
+        "governança"
+      ],
+      "description": "Produzir parecer técnico sobre ajustes éticos e de conformidade necessários antes da escala, com recomendações priorizadas.",
+      "entregaveis": [
+        "Parecer técnico com ajustes éticos priorizados.",
+        "Plano de implementação das recomendações de conformidade."
+      ],
+      "criterios_aceite": [
+        "Recomendações têm responsável e prazo definidos.",
+        "Comitê de governança valida o parecer."
+      ]
+    },
+    {
+      "title": "[Gate] Recomendação formal para escala (M4)",
+      "milestone": "M4",
+      "labels": [
+        "fase:iv",
+        "tipo:gate",
+        "governança"
+      ],
+      "description": "Realizar gate para decidir recomendação formal de escala com base em impacto comprovado, estabilidade técnica e aderência ética/operacional.",
+      "entregaveis": [
+        "Checklist de gate de M4 preenchido.",
+        "Recomendação formal de escala (ou não) emitida."
+      ],
+      "criterios_aceite": [
+        "Impacto e estabilidade no piloto foram comprovados.",
+        "Decisão formal registrada com justificativas."
+      ]
+    },
+    {
+      "title": "[Atividade] Preparar release package de produção",
+      "milestone": "M5",
+      "labels": [
+        "fase:v",
+        "tipo:atividade",
+        "software"
+      ],
+      "description": "Preparar pacote de release para produção contendo artefatos validados (imagens, binários, scripts), instruções de implantação e critérios de rollback.",
+      "entregaveis": [
+        "Pacote de release com artefatos de produção validados.",
+        "Procedimento de deploy e rollback documentado."
+      ],
+      "criterios_aceite": [
+        "Pacote pode ser implantado sem passos manuais ambíguos.",
+        "Checklist de segurança e operação foi atendido."
+      ]
+    },
+    {
+      "title": "[Atividade] Executar transferência tecnológica para órgão demandante",
+      "milestone": "M5",
+      "labels": [
+        "fase:v",
+        "tipo:atividade",
+        "software",
+        "governança"
+      ],
+      "description": "Executar plano de transferência tecnológica para o órgão demandante, incluindo capacitação, documentação e transição assistida de operação.",
+      "entregaveis": [
+        "Plano executado de transferência e capacitação.",
+        "Registro de treinamentos e materiais repassados."
+      ],
+      "criterios_aceite": [
+        "Equipe do órgão consegue operar a solução com autonomia inicial.",
+        "Pendências de transição foram tratadas e registradas."
+      ]
+    },
+    {
+      "title": "[Atividade] Definir e operacionalizar matriz de monitoramento/observabilidade",
+      "milestone": "M5",
+      "labels": [
+        "fase:v",
+        "tipo:atividade",
+        "software",
+        "ml",
+        "governança"
+      ],
+      "description": "Definir e operacionalizar matriz de monitoramento e observabilidade com indicadores, alertas, rotinas de resposta e governança de incidentes.",
+      "entregaveis": [
+        "Matriz de monitoramento com indicadores e alertas.",
+        "Runbook de incidentes e rotinas operacionais."
+      ],
+      "criterios_aceite": [
+        "Alertas críticos estão ativos e testados.",
+        "Responsáveis por resposta e escalonamento foram definidos."
+      ]
+    },
+    {
+      "title": "[Atividade] Formalizar governança, papéis e responsabilidades",
+      "milestone": "M5",
+      "labels": [
+        "fase:v",
+        "tipo:atividade",
+        "governança"
+      ],
+      "description": "Formalizar modelo de governança da solução em produção, com papéis, responsabilidades, fluxos decisórios e acordos de operação.",
+      "entregaveis": [
+        "Documento de governança com papéis e responsabilidades.",
+        "Fluxo decisório e ritos de acompanhamento formalizados."
+      ],
+      "criterios_aceite": [
+        "Papéis e alçadas estão aprovados pelos responsáveis.",
+        "Modelo de governança está aplicável em operação contínua."
+      ]
+    },
+    {
+      "title": "[Entregável] Release package validado",
+      "milestone": "M5",
+      "labels": [
+        "fase:v",
+        "tipo:entregavel",
+        "software"
+      ],
+      "description": "Entregar release package validado para produção com checklist de qualidade, segurança, desempenho e operação concluído.",
+      "entregaveis": [
+        "Release package aprovado para produção.",
+        "Registro de validações técnicas e operacionais."
+      ],
+      "criterios_aceite": [
+        "Pacote atende critérios de qualidade definidos.",
+        "Aprovação de publicação em produção foi formalizada."
+      ]
+    },
+    {
+      "title": "[Entregável] Kit de Transferência Tecnológica",
+      "milestone": "M5",
+      "labels": [
+        "fase:v",
+        "tipo:entregavel",
+        "software",
+        "governança"
+      ],
+      "description": "Entregar kit de transferência tecnológica com repositório, manuais, materiais de capacitação e matriz operacional de monitoramento.",
+      "entregaveis": [
+        "Kit com repositório, manuais e materiais de capacitação.",
+        "Matriz operacional de monitoramento incluída no kit."
+      ],
+      "criterios_aceite": [
+        "Kit é suficiente para operação e evolução local.",
+        "Itens do kit estão versionados e acessíveis ao órgão."
+      ]
+    },
+    {
+      "title": "[Entregável] Termo de Transferência de Tecnologia assinado",
+      "milestone": "M5",
+      "labels": [
+        "fase:v",
+        "tipo:entregavel",
+        "governança"
+      ],
+      "description": "Obter e registrar termo de transferência de tecnologia assinado pelas partes, formalizando a conclusão da transição operacional.",
+      "entregaveis": [
+        "Termo de transferência assinado pelas partes.",
+        "Registro formal do aceite da transição operacional."
+      ],
+      "criterios_aceite": [
+        "Documento assinado está arquivado e rastreável.",
+        "Responsabilidades pós-transferência estão explícitas."
+      ]
+    },
+    {
+      "title": "[Gate] Encerramento formal do projeto (M5)",
+      "milestone": "M5",
+      "labels": [
+        "fase:v",
+        "tipo:gate",
+        "governança"
+      ],
+      "description": "Conduzir gate final para confirmar solução operacionalizada, governança estabelecida e encerramento formal do projeto com aceite institucional.",
+      "entregaveis": [
+        "Checklist final de encerramento preenchido.",
+        "Ata de encerramento com aceite institucional."
+      ],
+      "criterios_aceite": [
+        "Solução está operacionalizada com governança ativa.",
+        "Comitê confirma encerramento formal do projeto."
+      ]
+    }
   ]
 }

--- a/scripts/roadmap_builder.py
+++ b/scripts/roadmap_builder.py
@@ -51,6 +51,15 @@ def require_list(value: Any, name: str, errors: list[str]) -> list[Any]:
     return value
 
 
+def validate_string_list(value: Any, name: str, errors: list[str]) -> None:
+    if not isinstance(value, list) or not value:
+        errors.append(f"`{name}` deve ser uma lista nao vazia")
+        return
+    for idx, item in enumerate(value, start=1):
+        if not isinstance(item, str) or not item.strip():
+            errors.append(f"`{name}[{idx}]` deve ser um texto nao vazio")
+
+
 def duplicate_values(values: list[str]) -> list[str]:
     seen: set[str] = set()
     duplicates: set[str] = set()
@@ -209,6 +218,13 @@ def validate_config(cfg: dict[str, Any]) -> list[str]:
         for label_name in issue_labels:
             if label_name not in label_name_set:
                 errors.append(f"`issues[{index}]` referencia label inexistente: {label_name}")
+
+        entregaveis = issue.get("entregaveis")
+        criterios_aceite = issue.get("criterios_aceite")
+        if entregaveis is not None:
+            validate_string_list(entregaveis, f"issues[{index}].entregaveis", errors)
+        if criterios_aceite is not None:
+            validate_string_list(criterios_aceite, f"issues[{index}].criterios_aceite", errors)
 
     for title in duplicate_values(issue_titles):
         errors.append(f"Issue duplicada: {title}")
@@ -415,17 +431,25 @@ def issue_body(issue: dict[str, Any], schedule: dict[str, Any] | None = None) ->
             f"- Duracao estimada do milestone: {schedule['duration_value']} {unit_label}\n"
         )
 
+    objetivo = issue.get("description", "Executar esta atividade conforme o processo da Fabrica de IA.")
+
+    entregaveis = issue.get("entregaveis", ["Evidencia principal anexada", "Criterios de aceite validados"])
+    criterios_aceite = issue.get(
+        "criterios_aceite",
+        ["Resultado revisado com stakeholders", "Registro no Project atualizado"],
+    )
+    entregaveis_block = "\n".join(f"- [ ] {item}" for item in entregaveis)
+    criterios_block = "\n".join(f"- [ ] {item}" for item in criterios_aceite)
+
     return (
         "## Contexto\n"
         f"Fase/marco: **{issue['milestone']}**.\n\n"
         "## Objetivo\n"
-        "Executar esta atividade conforme o processo da Fabrica de IA.\n\n"
+        f"{objetivo}\n\n"
         "## Entregaveis\n"
-        "- [ ] Evidencia principal anexada\n"
-        "- [ ] Criterios de aceite validados\n\n"
+        f"{entregaveis_block}\n\n"
         "## Criterios de aceite\n"
-        "- [ ] Resultado revisado com stakeholders\n"
-        "- [ ] Registro no Project atualizado\n"
+        f"{criterios_block}\n"
         f"{schedule_block}"
     )
 


### PR DESCRIPTION
### Motivation

- Add richer metadata to backlog issues so each issue can carry a `description` (objective), `entregaveis` and `criterios_aceite` for clearer scope and handoff. 
- Ensure roadmap generation validates these new fields to prevent malformed backlog data. 
- Provide additional role labels (e.g. `dados`, `ml`, `software`, `governança`) to tag responsibilities on issues.

### Description

- Expanded `backlog_github_project.json` issue objects with `description`, `entregaveis`, and `criterios_aceite`, and added several new labels for role/ownership; also reformatted JSON for readability. 
- Added `validate_string_list` to `scripts/roadmap_builder.py` and wired validation of `issues[].entregaveis` and `issues[].criterios_aceite` inside `validate_config`. 
- Updated `issue_body` in `scripts/roadmap_builder.py` to use `description` as the issue objective and to render `entregaveis` and `criterios_aceite` as checklist items with sensible defaults. 

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef65fd03048327a98d920d136dcd41)